### PR TITLE
Fix #5857: Add threadId to MapExecuteOnKey requests

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1085,14 +1085,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Object executeOnKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        ClientMessage request = MapExecuteOnKeyCodec.encodeRequest(name, toData(entryProcessor), keyData);
+        ClientMessage request = MapExecuteOnKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, ThreadUtil.getThreadId());
         return invoke(request, keyData);
     }
 
     public void submitToKey(K key, EntryProcessor entryProcessor, final ExecutionCallback callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData);
+        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, ThreadUtil.getThreadId());
         try {
             final ICompletableFuture future = invokeOnKeyOwner(request, keyData);
             future.andThen(callback);
@@ -1104,7 +1104,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Future submitToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData);
+        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, ThreadUtil.getThreadId());
 
         try {
             final ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -899,14 +899,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Object executeOnKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData);
+        MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData, ThreadUtil.getThreadId());
         return invoke(request, keyData);
     }
 
     public void submitToKey(K key, EntryProcessor entryProcessor, final ExecutionCallback callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData);
+        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData, ThreadUtil.getThreadId());
         request.setAsSubmitToKey();
         try {
             final ICompletableFuture future = invokeOnKeyOwner(request, keyData);
@@ -919,7 +919,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Future submitToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData);
+        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData, ThreadUtil.getThreadId());
         request.setAsSubmitToKey();
         try {
             final ICompletableFuture future = invokeOnKeyOwner(request, keyData);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeyMessageTask.java
@@ -40,7 +40,9 @@ public class MapExecuteOnKeyMessageTask
     @Override
     protected Operation prepareOperation() {
         final EntryProcessor processor = serializationService.toObject(parameters.entryProcessor);
-        return new EntryOperation(parameters.name, parameters.key, processor);
+        EntryOperation op = new EntryOperation(parameters.name, parameters.key, processor);
+        op.setThreadId(parameters.threadId);
+        return op;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -178,10 +178,10 @@ public interface MapCodecTemplate {
     void clear(String name);
 
     @Request(id = 50, retryable = false, response = ResponseMessageConst.DATA)
-    void executeOnKey(String name, Data entryProcessor, Data key);
+    void executeOnKey(String name, Data entryProcessor, Data key, long threadId);
 
     @Request(id = 51, retryable = false, response = ResponseMessageConst.DATA)
-    void submitToKey(String name, Data entryProcessor, Data key);
+    void submitToKey(String name, Data entryProcessor, Data key, long threadId);
 
     @Request(id = 52, retryable = false, response = ResponseMessageConst.SET_ENTRY)
     void executeOnAllKeys(String name, Data entryProcessor);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapExecuteOnKeyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapExecuteOnKeyRequest.java
@@ -40,14 +40,16 @@ public class MapExecuteOnKeyRequest extends KeyBasedClientRequest implements Por
     private Data key;
     private EntryProcessor processor;
     private boolean submitToKey;
+    private long threadId;
 
     public MapExecuteOnKeyRequest() {
     }
 
-    public MapExecuteOnKeyRequest(String name, EntryProcessor processor, Data key) {
+    public MapExecuteOnKeyRequest(String name, EntryProcessor processor, Data key, long threadId) {
         this.name = name;
         this.processor = processor;
         this.key = key;
+        this.threadId = threadId;
     }
 
     @Override
@@ -57,7 +59,9 @@ public class MapExecuteOnKeyRequest extends KeyBasedClientRequest implements Por
 
     @Override
     protected Operation prepareOperation() {
-        return new EntryOperation(name, key, processor);
+        EntryOperation op = new EntryOperation(name, key, processor);
+        op.setThreadId(threadId);
+        return op;
     }
 
     public String getServiceName() {


### PR DESCRIPTION
- Add threadId as a long to MapExecuteOnKeyRequest, which should tag the request as the id of the current thread, typically from ThreadUtils.getThreadId. Similarly, add threadId to the client protocol MapCodecTemplate relating to executeOnKey and submitToKey. 
- Set threadId in the EntryOperation returned by MapExecuteOnKeyRequest.prepareOperation and MapExecuteOnKeyMessageTask.prepareOperation.
- Supply threadId in ClientMapProxy when creating such requests.
